### PR TITLE
Make parse_h3cell faster

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ fn parse_h3cell(hex: H3Cell) -> Vec<usize> {
         return Vec::new();
     }
 
-    (0..(resolution - 1))
+    (0..resolution)
         .into_iter()
         .rev()
         .map(|r| {
@@ -45,7 +45,7 @@ impl Node {
     pub fn new() -> Self {
         Self {
             children: Box::new([None, None, None, None, None, None, None]),
-            full: false
+            full: false,
         }
     }
 
@@ -69,18 +69,17 @@ impl Node {
             Some(digit) => {
                 // TODO check if this node is "full"
                 match self.children[digit].as_mut() {
-                    Some(node) =>
-                        node.insert(digits),
+                    Some(node) => node.insert(digits),
                     None => {
                         let mut node = Node::new();
                         node.insert(digits);
                         self.children[digit] = Some(node);
                     }
                 }
-            },
+            }
             None => {
                 self.full = true;
-                return
+                return;
             }
         }
     }
@@ -88,7 +87,7 @@ impl Node {
     pub fn contains(&self, mut digits: Vec<usize>) -> bool {
         if self.full {
             //println!("full {:?}", digits);
-            return true
+            return true;
         }
 
         //println!("checking {:?}", digits);
@@ -99,15 +98,14 @@ impl Node {
                     Some(node) => {
                         //println!("had node");
                         node.contains(digits)
-                    },
+                    }
                     None => {
                         //println!("no node {:?}", self.children);
                         false
                     }
                 }
-            },
-            None =>
-                true
+            }
+            None => true,
         }
     }
 }
@@ -141,7 +139,7 @@ impl HTree {
         let base_cell = hex.base_cell_number();
         match self.nodes.get(&base_cell) {
             Some(node) => node.contains(parse_h3cell(hex)),
-            None => false
+            None => false,
         }
     }
 }
@@ -175,7 +173,6 @@ mod tests {
             tree
         }
 
-
         let us915 = from_array(&hexagons);
 
         assert_eq!(us915.len(), hexagons.len());
@@ -192,10 +189,7 @@ mod tests {
         assert!(!us915.contains(gulf_of_mexico));
         assert!(!us915.contains(paris));
 
-        println!(
-            "new from us915: {}",
-            bench(|| from_array(&hexagons))
-        );
+        println!("new from us915: {}", bench(|| from_array(&hexagons)));
         println!(
             "us915.contains(tarpon_springs): {}",
             bench(|| us915.contains(tarpon_springs))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,23 +18,20 @@ fn parse_h3cell(hex: H3Cell) -> Vec<usize> {
     let index = hex.h3index();
     let resolution = hex.resolution();
 
-    let mut children = Vec::new();
-
     if resolution == 0 {
-        return children;
+        return Vec::new();
     }
 
-    //println!("hex resolution {}", resolution);
-
-    for r in 0..(resolution - 1) {
-        let offset = 0x2a - ( 3 * r);
-        let digit = (index >> offset) & 0b111;
-        //println!("offset {} digit {} resolution {}", offset, digit, r+1);
-        assert!(digit >= 0 && digit < 7);
-        children.push(digit as usize);
-    }
-    children.reverse();
-    return children;
+    (0..(resolution - 1))
+        .into_iter()
+        .rev()
+        .map(|r| {
+            let offset = 0x2a - (3 * r);
+            let digit = (index >> offset) & 0b111;
+            assert!(digit < 7);
+            digit as usize
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -77,7 +74,6 @@ impl Node {
     }
 
     pub fn contains(&self, mut digits: Vec<usize>) -> bool {
-        let full = self.children.iter().all(|c| c.is_none());
         if self.full {
             //println!("full {:?}", digits);
             return true


### PR DESCRIPTION
it looks like parse_h3cell is the biggest bottleneck. This patch makes the test cases almost 3x faster on my machine.

Additionally, I added a `.len()` method. With it, I discovered that the `- 1` was making an HTree with only 836 leaves instead of the 42383 contained in the source region.